### PR TITLE
Replace python array type code 'u' with 'w'

### DIFF
--- a/src/seguid/_manip.py
+++ b/src/seguid/_manip.py
@@ -91,7 +91,7 @@ def min_rotation_py(s: str) -> int:
     """
 
     prev, rep = None, 0
-    ds = array("u", 2 * s)
+    ds = array("w", 2 * s)
     lens = len(s)
     lends = lens * 2
     old = 0


### PR DESCRIPTION
'u' format code is deprecated and will be removed soon: 
https://docs.python.org/3/deprecations/index.html#pending-removal-in-python-3-16